### PR TITLE
Remove `@Nullable` annotation.

### DIFF
--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -8,7 +8,6 @@ import android.os.AsyncTask;
 import android.os.Environment;
 import android.os.StatFs;
 import android.provider.MediaStore;
-import androidx.annotation.Nullable;
 import android.util.Base64;
 import android.util.SparseArray;
 import android.media.MediaScannerConnection;
@@ -682,7 +681,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
     }
   }
 
-  private void sendEvent(ReactContext reactContext, String eventName, @Nullable WritableMap params) {
+  private void sendEvent(ReactContext reactContext, String eventName, WritableMap params) {
     reactContext
             .getJSModule(RCTNativeAppEventEmitter.class)
             .emit(eventName, params);


### PR DESCRIPTION
- This removes the dependency on `android.support` and `androidx`. 
Side-stepping the need to make a major change to the project to support 
both libraries.